### PR TITLE
fixing bug with EC2 teardown when disassociating EIPs

### DIFF
--- a/playbooks/roles/provision_aws/tasks/ec2.yml
+++ b/playbooks/roles/provision_aws/tasks/ec2.yml
@@ -141,7 +141,6 @@
   ec2_eip:
     device_id: "{{ item }}"
     region: "{{ aws_region }}"
-    release_on_disassociation: yes
     state: present
   with_items:
     - "{{ ec2_create_master_instance.instances | map(attribute='instance_id') | list }}"

--- a/playbooks/roles/provision_aws/tasks/ec2_teardown.yml
+++ b/playbooks/roles/provision_aws/tasks/ec2_teardown.yml
@@ -12,6 +12,7 @@
   ec2_eip:
     device_id: "{{ item.instance_id }}"
     region: "{{ aws_region }}"
+    release_on_disassociation: yes
     state: absent
   with_items: "{{ ec2_find_instances.instances }}"
 


### PR DESCRIPTION
It seems like this parameter only gets processed on `state:absent`. It was leaving EIPs behind, this change fixed it for me.