### PR TITLE
EIP Creation Fails in Region Where EC2-Classic is Available

### DIFF
--- a/playbooks/roles/provision_aws/tasks/ec2.yml
+++ b/playbooks/roles/provision_aws/tasks/ec2.yml
@@ -142,6 +142,8 @@
     device_id: "{{ item }}"
     region: "{{ aws_region }}"
     state: present
+    in_vpc: yes
   with_items:
     - "{{ ec2_create_master_instance.instances | map(attribute='instance_id') | list }}"
     - "{{ ec2_create_infra_instance.instances | map(attribute='instance_id') | list }}"
+    


### PR DESCRIPTION
#### What's this PR do?

When running the provision command in an account/region where ec2-classic is available, the EIPs are created with standard networking (not VPC) and fail to attach to the EC2 instances.

#### Where should the reviewer start?

Review the documentation and cxhange to the ec2.yml tasks file to add in_vpc: true.

#### How should this be manually tested?

An account/region with ec2-classic available must be used to test the error. Any account can be used to test for the regression case.

#### Any background context you want to provide?

I ran into this issue in my account, which has the following supported:

![screenshot from 2018-08-21 19-20-22](https://user-images.githubusercontent.com/244013/44434510-748fb100-a579-11e8-815e-e2b7a11edee0.png)